### PR TITLE
Correct Despawn

### DIFF
--- a/ManagedServer/Entities/Types/Entity.cs
+++ b/ManagedServer/Entities/Types/Entity.cs
@@ -238,8 +238,8 @@ public class Entity : MappedTaggable, IViewable, IFeatureScope {
     }
 
     public void Despawn() {
-        Manager!.BaseEventNode.RemoveChild(Events);
-        Manager.Despawn(this);
+        Manager?.BaseEventNode.RemoveChild(Events);
+        Manager?.Despawn(this);
         Manager = null;
         World = null;
     }


### PR DESCRIPTION
I don't know why, but before the Despawn method is called, the Manager variable already becomes null. This fix helps solve the problem, but it's not a panacea because of BaseEventNode. The issue mostly occurs more frequently when a large number of entities disappear from the player's field of view. (Teleport, Disconnect)